### PR TITLE
Added Shortest wait at chairlift Widget

### DIFF
--- a/src/main/res/layout/statistics_per_day.xml
+++ b/src/main/res/layout/statistics_per_day.xml
@@ -188,5 +188,27 @@
             app:layout_constraintEnd_toStartOf="@id/guideline3"
             app:layout_constraintTop_toBottomOf="@id/stats_speed_barrier"/>
 
+        <!-- Shortest wait at chairlift -->
+        <TextView
+            android:id="@+id/stats_shortest_wait_label"
+            style="@style/TextAppearance.OpenTracks.PrimaryHeader"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Shortest wait at chairlift"
+            app:layout_constrainedWidth="true"
+            app:layout_constraintStart_toEndOf="@id/guideline"
+            app:layout_constraintEnd_toStartOf="@id/guideline2"
+            app:layout_constraintTop_toBottomOf="@id/stats_waiting_horizontal_line" />
+
+        <TextView
+            android:id="@+id/stats_shortest_wait_value"
+            style="@style/TextAppearance.OpenTracks.PrimaryValue"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintStart_toEndOf="@id/guideline"
+            app:layout_constraintTop_toBottomOf="@id/stats_shortest_wait_label"
+            tools:text="00:00:00" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 </ScrollView>


### PR DESCRIPTION
Added Shortest wait at chairlift Widget

**Describe the pull request**
Statistics - Aggregate Per Day (Ski/ChairLift) - Shortest Wait at Ski Chairlift - This feature aims to introduce a UI component
for displaying the shortest wait time at the ski chairlift, aggregated per day.

**Challenges I faced**
Faced some difficulties understanding and working with program syntax. Faced difficulties communicating and collaborating with entire groups.

**Link to the the issue**
Issue Link:- [Subtask Issue Link](https://github.com/rilling/OpenTracks-Winter-SOEN-6431_2024/issues/190)

