### PR TITLE
Added Total waiting time at chairlift widget

### DIFF
--- a/src/main/res/layout/statistics_per_day.xml
+++ b/src/main/res/layout/statistics_per_day.xml
@@ -210,7 +210,7 @@
             app:layout_constraintTop_toBottomOf="@id/stats_shortest_wait_label"
             tools:text="00:00:00" />
 
-               <!-- Longest wait at chairlift -->
+        <!-- Longest wait at chairlift -->
         <TextView
             android:id="@+id/stats_longest_wait_label"
             style="@style/TextAppearance.OpenTracks.PrimaryHeader"
@@ -248,6 +248,28 @@
             app:layout_constraintStart_toEndOf="@id/guideline"
             app:layout_constraintEnd_toStartOf="@id/guideline3"
             app:layout_constraintTop_toBottomOf="@id/stats_time_barrier" />
+
+        <!-- Average waiting time -->
+        <TextView
+            android:id="@+id/stats_moving_time_label"
+            style="@style/TextAppearance.OpenTracks.PrimaryHeader"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Average waiting time at chairlift"
+            app:layout_constrainedWidth="true"
+            app:layout_constraintStart_toEndOf="@id/guideline"
+            app:layout_constraintEnd_toStartOf="@id/guideline2"
+            app:layout_constraintTop_toBottomOf="@id/stats_distance_horizontal_line" />
+
+        <TextView
+            android:id="@+id/stats_moving_time_value"
+            style="@style/TextAppearance.OpenTracks.PrimaryValue"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:value="@string/value_unknown"
+            app:layout_constraintStart_toEndOf="@id/guideline"
+            app:layout_constraintTop_toBottomOf="@id/stats_moving_time_label"
+            tools:text="00:00:00" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </ScrollView>


### PR DESCRIPTION
Added Total waiting time at chairlift widget

**Describe the pull request**
Statistics (aggregate per day (ski/chairlift) - Total Waiting Time for Chairlifts) - This feature is
to design and implement a UI element for displaying the total time spent waiting for chairlifts throughout the day.

**Challenges I faced**
Faced some difficulties understanding and working with program syntax. Faced difficulties communicating and collaborating with entire groups.

**Link to the the issue**
Issue Link:- [Subtask Issue Link](https://github.com/rilling/OpenTracks-Winter-SOEN-6431_2024/issues/192)

