### PR TITLE
added structure and linked per day statistics page

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -92,6 +92,9 @@ limitations under the License.
             android:name=".ui.aggregatedStatistics.SeasonStats.SeasonStatActivity"
             android:exported="false" />
         <activity
+            android:name=".ui.aggregatedStatistics.daystatistics.DayStatisticsActivity"
+            android:exported="false" />
+        <activity
             android:name=".publicapi.StartRecording"
             android:exported="true"
             android:theme="@style/SplashTheme">

--- a/src/main/java/de/dennisguse/opentracks/ui/aggregatedStatistics/AggregatedStatisticsAdapter.java
+++ b/src/main/java/de/dennisguse/opentracks/ui/aggregatedStatistics/AggregatedStatisticsAdapter.java
@@ -23,6 +23,7 @@ import de.dennisguse.opentracks.settings.PreferencesUtils;
 import de.dennisguse.opentracks.settings.UnitSystem;
 import de.dennisguse.opentracks.ui.aggregatedStatistics.SeasonStats.SeasonStatActivity;
 import de.dennisguse.opentracks.ui.aggregatedStatistics.daySpecificStats.DaySpecificActivity;
+import de.dennisguse.opentracks.ui.aggregatedStatistics.daystatistics.DayStatisticsActivity;
 import de.dennisguse.opentracks.util.StringUtils;
 
 public class AggregatedStatisticsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
@@ -117,6 +118,14 @@ public class AggregatedStatisticsAdapter extends RecyclerView.Adapter<RecyclerVi
                 public void onClick(View v) {
                     Context context = viewBinding.getRoot().getContext();
                     Intent intent = new Intent(context, DaySpecificActivity.class);
+                }
+            });
+
+            viewBinding.dayStatisticsBtn.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View view) {
+                    Context context = viewBinding.getRoot().getContext();
+                    Intent intent = new Intent(context, DayStatisticsActivity.class);
                     context.startActivity(intent);
                 }
             });

--- a/src/main/java/de/dennisguse/opentracks/ui/aggregatedStatistics/daystatistics/DayStatisticsActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/ui/aggregatedStatistics/daystatistics/DayStatisticsActivity.java
@@ -1,0 +1,24 @@
+package de.dennisguse.opentracks.ui.aggregatedStatistics.daystatistics;
+
+import android.os.Bundle;
+import android.view.View;
+
+import de.dennisguse.opentracks.AbstractActivity;
+import de.dennisguse.opentracks.databinding.StatisticsPerDayBinding;
+
+public class DayStatisticsActivity extends AbstractActivity {
+
+    private StatisticsPerDayBinding viewBinding;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    protected View getRootView() {
+        viewBinding = StatisticsPerDayBinding.inflate(getLayoutInflater());
+        return viewBinding.getRoot();
+    }
+
+}

--- a/src/main/res/layout/aggregated_stats_list_item.xml
+++ b/src/main/res/layout/aggregated_stats_list_item.xml
@@ -217,10 +217,23 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
-        android:text="Seasons"
         android:gravity="center"
-        app:layout_constraintStart_toStartOf="parent"
+        android:text="Seasons"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.16"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/aggregated_stats_horizontal_line" />
+
+    <Button
+        android:id="@+id/day_statistics_btn"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:gravity="center"
+        android:text="Day Statistics"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.884"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/aggregated_stats_horizontal_line" />
 
     <Button


### PR DESCRIPTION
Added Structure and linked per day statistics

**Describe the pull request**
Created the overall structure for linking per day statistics related page from aggregated stats page. The per day statistics page is used to display all information related to ski stats per day.

**Challenges I faced**

- Faced some difficulties understanding and working with program syntax.
- Faced difficulties communicating and collaborating with entire groups.

**Link to the the issue**
Issue Link:- [Subtask Issue Link](https://github.com/rilling/OpenTracks-Winter-SOEN-6431_2024/issues/194)
